### PR TITLE
Fix analysis route URL /analyses/ → /api/analysis/

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -67,7 +67,7 @@ function App() {
       }
 
       // Récupérer les détails de l'analyse avec les vulnérabilités
-      const detailRes = await fetch(`/analyses/${data.analysisId}`, {
+      const detailRes = await fetch(`/api/analysis/${data.analysisId}`, {
         headers: {
           'Authorization': `Bearer ${token}`,
         },


### PR DESCRIPTION
## Summary
- Corrige l'URL du fetch analysis dans App.jsx pour correspondre au changement de route backend (PR #28)
- `/analyses/:id` → `/api/analysis/:id`

## Impact
Sans ce fix, le Dashboard et Findings affichent 0 résultats car la route retourne un 404.